### PR TITLE
MatchControlのStateをScriptableObjectにした

### DIFF
--- a/StaaaaaaaaaaakBuild/Assets/Scripts/Game/MatchControl.cs
+++ b/StaaaaaaaaaaakBuild/Assets/Scripts/Game/MatchControl.cs
@@ -33,6 +33,7 @@ namespace StackBuild.Game
         [Header("System")]
         [SerializeField] private PlayerInputProperty playerInputProperty;
         [SerializeField] private PlayerProperty[] players;
+        [SerializeField] private MatchControlState matchControlState;
 
         private float timeRemaining;
         private readonly ReactiveProperty<MatchState> state = new();
@@ -47,6 +48,7 @@ namespace StackBuild.Game
         private async UniTaskVoid RunMatch()
         {
             state.Value = MatchState.Starting;
+            matchControlState.SendState(MatchState.Starting);
 
             DisablePlayerMovement();
             AnimateCamera();
@@ -70,6 +72,7 @@ namespace StackBuild.Game
             await UniTask.Delay(TimeSpan.FromSeconds(startDelay));
             timeRemaining = gameTime;
             state.Value = MatchState.Ingame;
+            matchControlState.SendState(MatchState.Ingame);
             EnablePlayerMovement();
             startDisplay.gameObject.SetActive(true);
             startDisplay.Display();
@@ -78,6 +81,7 @@ namespace StackBuild.Game
         private async UniTaskVoid FinishMatch()
         {
             state.Value = MatchState.Finished;
+            matchControlState.SendState(MatchState.Finished);
             DisablePlayerMovement();
             foreach (var hud in huds)
             {

--- a/StaaaaaaaaaaakBuild/Assets/Scripts/Game/MatchControlState.cs
+++ b/StaaaaaaaaaaakBuild/Assets/Scripts/Game/MatchControlState.cs
@@ -1,0 +1,17 @@
+﻿using UniRx;
+using UnityEngine;
+
+namespace StackBuild.Game
+{
+    [CreateAssetMenu(menuName = "ScriptableObject/MatchControl/MatchControlState")]
+    public class MatchControlState : ScriptableObject
+    {
+        public IReadOnlyReactiveProperty<MatchState> State => state;
+        private ReactiveProperty<MatchState> state = new ReactiveProperty<MatchState>();
+
+        public void SendState(MatchState matchState)
+        {
+            state.Value = matchState;
+        }
+    }
+}

--- a/StaaaaaaaaaaakBuild/Assets/Scripts/Game/MatchControlState.cs.meta
+++ b/StaaaaaaaaaaakBuild/Assets/Scripts/Game/MatchControlState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d167c0ba4e424b5ebe78b022df4189e3
+timeCreated: 1671722197

--- a/StaaaaaaaaaaakBuild/Assets/Settings/MatchControl.meta
+++ b/StaaaaaaaaaaakBuild/Assets/Settings/MatchControl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8012d3d5ff134594fb579f1ad41bd29b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StaaaaaaaaaaakBuild/Assets/Settings/MatchControl/Match Control State.asset
+++ b/StaaaaaaaaaaakBuild/Assets/Settings/MatchControl/Match Control State.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d167c0ba4e424b5ebe78b022df4189e3, type: 3}
+  m_Name: Match Control State
+  m_EditorClassIdentifier: 

--- a/StaaaaaaaaaaakBuild/Assets/Settings/MatchControl/Match Control State.asset.meta
+++ b/StaaaaaaaaaaakBuild/Assets/Settings/MatchControl/Match Control State.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4e15217affc4c74a9f69eb55eb8f6da
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
エラーが大量に出るため前のMatchStateはそのまま