### PR TITLE
オンライン対戦の物理キモキモ修正

### DIFF
--- a/StaaaaaaaaaaakBuild/Assets/Scripts/Goal/GoalCore.cs
+++ b/StaaaaaaaaaaakBuild/Assets/Scripts/Goal/GoalCore.cs
@@ -74,6 +74,7 @@ namespace StackBuild
 
                 if (networkSync.IsSpawned)
                 {
+                    networkSync.LostOwnershipServerRpc(NetworkManager.ServerClientId);
                     EnqueueServerRpc(i);
                 }
                 else

--- a/StaaaaaaaaaaakBuild/Assets/Scripts/Parts/PartsNetworkSync.cs
+++ b/StaaaaaaaaaaakBuild/Assets/Scripts/Parts/PartsNetworkSync.cs
@@ -55,16 +55,6 @@ namespace StackBuild
 
                     ChangeOwnershipServerRpc(player.OwnerClientId);
                 }).AddTo(this);
-
-            this.OnTriggerExitAsObservable()
-                .Where(col => col.CompareTag("Catch"))
-                .Select(col => col.transform.parent.parent.GetComponent<NetworkObject>())
-                .Subscribe(player =>
-                {
-                    LostOwnershipServerRpc(NetworkManager.ServerClientId, rb.position);
-                    // UpdatePositionServerRpc(rb.position);
-                    // UpdateVelocityServerRpc(rb.velocity);
-                }).AddTo(this);
         }
 
         public override void OnNetworkDespawn()
@@ -82,14 +72,11 @@ namespace StackBuild
         }
 
         [ServerRpc(RequireOwnership = false)]
-        public void LostOwnershipServerRpc(ulong clientId, Vector3 position)
+        public void LostOwnershipServerRpc(ulong clientId)
         {
             if (!IsServer) return;
 
-            networkObject.RemoveOwnership();
             networkObject.ChangeOwnership(clientId);
-            rb.position = position + rb.velocity * Time.fixedDeltaTime * (extrapolateFromSeconds / 50.0f);
-            rb.velocity = Vector3.zero;
         }
 
         [ServerRpc(RequireOwnership = false)]


### PR DESCRIPTION
パーツは大砲発射時にサーバーをオーナーにしないといけない。
なら、大砲発射前の待機状態になるときにオーナーにすればよい。
ゴール入った時と場外に落ちた時にオーナーをサーバーに返して、掴んだ時にオーナーを貰えば解決！！